### PR TITLE
[VE-8] set up storybook to run all tests

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,8 +4,9 @@ module.exports = {
     '../stories/**/*.stories.@(js|jsx|ts|tsx)',
   ],
   addons: [
-    '@storybook/addon-links',
     '@storybook/addon-essentials',
+    '@storybook/addon-links',
+    '@storybook/addon-actions',
     '@storybook/addon-interactions',
   ],
   framework: '@storybook/react',

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY package.json ./
 COPY package-lock.json ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f package-lock.json ]; then npm ci --only=prod --ignore-scripts; \
   elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm i; \
   else echo "Lockfile not found." && exit 1; \
   fi
@@ -21,17 +21,17 @@ RUN \
 FROM node:14-alpine AS builder
 WORKDIR /app/apps/venue
 
-ENV NODE_ENV production
-
 COPY --from=deps /app/package.json ./
 COPY --from=deps /app/node_modules ./node_modules
+COPY tailwind.config.js ./
 COPY . ../../
+
+# Install packages needed by the `build:docker` script (using `next build`)
+RUN npm i --save-dev typescript @types/react
 
 # Replace the Nx version of the Next config file with the non-Nx version
 RUN rm next.config.js
 RUN mv next.config-docker.js next.config.js
-
-RUN ls
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY tailwind.config.js ./
 COPY . ../../
 
 # Install packages needed by the `build:docker` script (using `next build`)
-RUN npm i --save-dev typescript @types/react
+RUN npm i --save-dev typescript @types/react @types/jest
 
 # Replace the Nx version of the Next config file with the non-Nx version
 RUN rm next.config.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:14-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
+# Only install production dependencies
+ENV NODE_ENV production
+
 # Install dependencies based on the preferred package manager
 COPY package.json ./
 COPY package-lock.json ./
@@ -17,6 +20,9 @@ RUN \
 # Rebuild the source code only when needed
 FROM node:14-alpine AS builder
 WORKDIR /app/apps/venue
+
+ENV NODE_ENV production
+
 COPY --from=deps /app/package.json ./
 COPY --from=deps /app/node_modules ./node_modules
 COPY . ../../

--- a/apps/venue/next.config-docker.js
+++ b/apps/venue/next.config-docker.js
@@ -1,12 +1,13 @@
 module.exports = {
-  typescript: {
+  /*typescript: {
     // !! WARN !!
     // Dangerously allow production builds to successfully complete even if
     // your project has type errors.
     // !! WARN !!
     ignoreBuildErrors: true,
-  },
+  },*/
   eslint: {
+    // NOTE: `eslint` will be used in Docker builds once Nx Executors can be used
     // Warning: This allows production builds to successfully complete even if
     // your project has ESLint errors.
     ignoreDuringBuilds: true,

--- a/apps/venue/next.config-docker.js
+++ b/apps/venue/next.config-docker.js
@@ -1,4 +1,11 @@
 module.exports = {
+  typescript: {
+    // !! WARN !!
+    // Dangerously allow production builds to successfully complete even if
+    // your project has type errors.
+    // !! WARN !!
+    ignoreBuildErrors: true,
+  },
   eslint: {
     // Warning: This allows production builds to successfully complete even if
     // your project has ESLint errors.

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "tailwind": "npx tailwindcss -i ./tailwind/input.css -o ./tailwind/output.css",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "test-storybook": "test-storybook",
-    "test-storybook:watch": "test-storybook --watch",
+    "test-storybook": "test-storybook --browsers chromium firefox webkit",
+    "test-storybook:watch": "test-storybook --browsers chromium firefox webkit --watch",
     "prepare": "husky install"
   },
   "lint-staged": {


### PR DESCRIPTION
On Git Push to the remote (GitHub), the Storybook **test-runner** (using Playwright) runs all UI tests on the Stories in the 3 major browser engines (Chromium, Firefox and WebKit).

The Git Push will abort when one or many tests fail.  This is set up using a Husky pre-push hook.

Non-UI tests are run on every Git Commit using a Husky pre-commit hook.