### PR TITLE
[dependency management] only trigger 'build-deploy' action on PR merge

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,6 +1,6 @@
 name: 'build'
-on: # rebuild any PRs and main branch changes
-  pull_request:
+on: # rebuild any main branch changes
+  # pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
This is only temporary since we only have a `test` environment deployed on AWS.

Once we add a `prod` environment we will need to create a new action that will deploy to the `test` environment on PRs made to the `main` branch AND we will need to update this current action to deploy to the `prod` environment on every PR merge to the `main` branch.